### PR TITLE
Iteration v0.2: runtime config + aspect-aware framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,28 +28,41 @@ Some environments are stricter about loading ES modules from `file:///` URLs. If
 
 ---
 
-## Quick configuration (speed, zoom, HUD)
+## Quick configuration (runtime query params)
 
 You can tweak behavior either by editing constants in `main.js` or by using query-string parameters.
 
 ### Query-string parameters
 Append these to the URL you load in Lively:
 
-- `sps` — steps per second (approx)
-  - Example: `index.html?sps=30`
-- `stepDelayMs` — delay between A* steps (overrides `sps`)
-  - Example: `index.html?stepDelayMs=25`
-- `zoom` — zoom into the Boston bounding box (>1 zooms in)
+- `bounds` — optional bounds preset
+  - Currently supported: `boston`
+  - Example: `index.html?bounds=boston`
+- `zoom` — zoom into the bounding box (>1 zooms in)
+  - Valid range: clamped to `[0.25, 6]`
   - Example: `index.html?zoom=1.25`
+- `stepsPerSecond` — target A* steps per second
+  - Valid range: clamped to `[1, 240]`
+  - Example: `index.html?stepsPerSecond=30`
+- `endHoldMs` — how long to hold the completed path before the reveal animation
+  - Example: `index.html?endHoldMs=2500`
+- `endAnimMs` — how long to run the end reveal animation
+  - Example: `index.html?endAnimMs=1600`
+- `minStartEndMeters` — minimum start↔goal distance for sampling
+  - Example: `index.html?minStartEndMeters=9000`
 - `hud` — show/hide the debug HUD (`hud=0` hides)
   - Example: `index.html?hud=0`
 
 Examples:
-- `index.html?sps=35&zoom=1.2`
-- `http://127.0.0.1:8000/index.html?sps=25&hud=0`
+- `index.html?stepsPerSecond=35&zoom=1.2`
+- `http://127.0.0.1:8000/index.html?stepsPerSecond=25&hud=0`
+
+Notes:
+- All values are validated/clamped; invalid values fall back to defaults.
+- If endpoint sampling can’t satisfy `minStartEndMeters` after N tries, a warning is shown in the HUD and it proceeds with the best pair found.
 
 ### Edit constants
-Open `main.js` and adjust the `CONFIG` object (e.g. `stepDelayMs`, `zoom`, `gridCols`, `gridRows`).
+Open `main.js` and adjust the `CONFIG` object (e.g. `gridCols`, `gridRows`, styling). Runtime values above are applied first.
 
 ---
 
@@ -73,4 +86,5 @@ python -m http.server 8000
 
 ## Notes / roadmap
 - Current graph is a **regular grid** (prototype).
+- Displayed bounds are framed to the **screen aspect ratio** while keeping a fixed center (Boston bbox center).
 - Road-network / OSM integration is a later step.

--- a/config.js
+++ b/config.js
@@ -1,0 +1,159 @@
+// Runtime config parsing + small geo framing helpers.
+// Keep this buildless: pure JS utilities consumed by main.js and node tests.
+
+export const BOUNDS_PRESETS = {
+  // Greater Boston (prototype)
+  boston: {
+    north: 42.55,
+    south: 42.2,
+    west: -71.35,
+    east: -70.85,
+  },
+};
+
+export const DEFAULT_RUNTIME = {
+  bounds: "boston",
+  zoom: 1.0,
+  stepsPerSecond: 20,
+  endHoldMs: 1800,
+  endAnimMs: 1200,
+  minStartEndMeters: 7000,
+  hud: true,
+
+  // Endpoint sampling behavior
+  endpointTries: 5000,
+};
+
+export function clamp(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function parseBoolish(v) {
+  if (v == null) return null;
+  const s = String(v).trim().toLowerCase();
+  if (["1", "true", "t", "yes", "y", "on"].includes(s)) return true;
+  if (["0", "false", "f", "no", "n", "off"].includes(s)) return false;
+  return null;
+}
+
+function parseFiniteNumber(v) {
+  if (v == null) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Parse runtime config from a query string.
+ *
+ * Supported params (documented):
+ * - bounds: preset name (e.g. "boston")
+ * - zoom
+ * - stepsPerSecond
+ * - endHoldMs
+ * - endAnimMs
+ * - minStartEndMeters
+ * - hud
+ *
+ * Returns: { runtime, warnings }
+ */
+export function parseRuntimeConfig(search, defaults = DEFAULT_RUNTIME) {
+  const warnings = [];
+  const sp = new URLSearchParams((search ?? "").startsWith("?") ? search : `?${search ?? ""}`);
+
+  const out = { ...defaults };
+
+  // bounds preset
+  if (sp.has("bounds")) {
+    const name = String(sp.get("bounds") ?? "").trim().toLowerCase();
+    if (name && BOUNDS_PRESETS[name]) out.bounds = name;
+    else warnings.push(`Invalid bounds preset: "${name}" (using "${defaults.bounds}")`);
+  }
+
+  // zoom
+  if (sp.has("zoom")) {
+    const z = parseFiniteNumber(sp.get("zoom"));
+    if (z == null) warnings.push(`Invalid zoom: "${sp.get("zoom")}" (using ${defaults.zoom})`);
+    else out.zoom = clamp(z, 0.25, 6.0);
+  }
+
+  // stepsPerSecond
+  if (sp.has("stepsPerSecond")) {
+    const sps = parseFiniteNumber(sp.get("stepsPerSecond"));
+    if (sps == null) warnings.push(`Invalid stepsPerSecond: "${sp.get("stepsPerSecond")}" (using ${defaults.stepsPerSecond})`);
+    else out.stepsPerSecond = clamp(sps, 1, 240);
+  }
+  // Back-compat alias (not documented in v0.2): sps
+  if (!sp.has("stepsPerSecond") && sp.has("sps")) {
+    const sps = parseFiniteNumber(sp.get("sps"));
+    if (sps != null) out.stepsPerSecond = clamp(sps, 1, 240);
+  }
+
+  // end timings
+  if (sp.has("endHoldMs")) {
+    const v = parseFiniteNumber(sp.get("endHoldMs"));
+    if (v == null) warnings.push(`Invalid endHoldMs: "${sp.get("endHoldMs")}" (using ${defaults.endHoldMs})`);
+    else out.endHoldMs = clamp(v, 0, 60000);
+  }
+
+  if (sp.has("endAnimMs")) {
+    const v = parseFiniteNumber(sp.get("endAnimMs"));
+    if (v == null) warnings.push(`Invalid endAnimMs: "${sp.get("endAnimMs")}" (using ${defaults.endAnimMs})`);
+    else out.endAnimMs = clamp(v, 0, 60000);
+  }
+
+  if (sp.has("minStartEndMeters")) {
+    const v = parseFiniteNumber(sp.get("minStartEndMeters"));
+    if (v == null)
+      warnings.push(`Invalid minStartEndMeters: "${sp.get("minStartEndMeters")}" (using ${defaults.minStartEndMeters})`);
+    else out.minStartEndMeters = clamp(v, 0, 200000);
+  }
+
+  if (sp.has("hud")) {
+    const b = parseBoolish(sp.get("hud"));
+    if (b == null) warnings.push(`Invalid hud: "${sp.get("hud")}" (using ${defaults.hud ? 1 : 0})`);
+    else out.hud = b;
+  }
+
+  return { runtime: out, warnings };
+}
+
+export function bboxCenter(bounds) {
+  return {
+    lat: (bounds.north + bounds.south) / 2,
+    lon: (bounds.east + bounds.west) / 2,
+  };
+}
+
+/**
+ * Aspect-ratio-aware framing around a fixed center.
+ *
+ * The "base" bounds define the unzoomed extent. We apply zoom, then expand
+ * either latitude or longitude span so that projected meters roughly match the
+ * screen aspect ratio. (Uses cos(latitude) correction for longitude.)
+ */
+export function framedBounds({ baseBounds, center, zoom, aspect }) {
+  const z = Math.max(1e-6, zoom);
+  let latSpan = (baseBounds.north - baseBounds.south) / z;
+  let lonSpan = (baseBounds.east - baseBounds.west) / z;
+
+  const latC = center.lat;
+  const cosLat = Math.max(0.15, Math.cos((latC * Math.PI) / 180));
+
+  const currentAspect = (lonSpan * cosLat) / Math.max(1e-9, latSpan);
+  if (Number.isFinite(aspect) && aspect > 0) {
+    if (currentAspect < aspect) {
+      // Too tall: widen lon span.
+      lonSpan = (aspect * latSpan) / cosLat;
+    } else if (currentAspect > aspect) {
+      // Too wide: increase lat span.
+      latSpan = (lonSpan * cosLat) / aspect;
+    }
+  }
+
+  return {
+    north: center.lat + latSpan / 2,
+    south: center.lat - latSpan / 2,
+    west: center.lon - lonSpan / 2,
+    east: center.lon + lonSpan / 2,
+  };
+}

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { DEFAULT_RUNTIME, parseRuntimeConfig } from '../config.js';
+
+test('parseRuntimeConfig clamps values and falls back on invalid inputs', ()=>{
+  const { runtime, warnings } = parseRuntimeConfig(
+    '?zoom=999&stepsPerSecond=-5&endHoldMs=abc&endAnimMs=50&minStartEndMeters=-10&hud=maybe&bounds=notapreset',
+    DEFAULT_RUNTIME
+  );
+
+  // clamps
+  assert.equal(runtime.zoom, 6.0);
+  assert.equal(runtime.stepsPerSecond, 1);
+  assert.equal(runtime.endAnimMs, 50);
+  assert.equal(runtime.minStartEndMeters, 0);
+
+  // invalids fall back to defaults
+  assert.equal(runtime.endHoldMs, DEFAULT_RUNTIME.endHoldMs);
+  assert.equal(runtime.hud, DEFAULT_RUNTIME.hud);
+  assert.equal(runtime.bounds, DEFAULT_RUNTIME.bounds);
+
+  assert.ok(warnings.length >= 3);
+});


### PR DESCRIPTION
- **What changed:** Added small runtime config system (query params: bounds, zoom, stepsPerSecond, endHoldMs, endAnimMs, minStartEndMeters, hud) with validation/clamping; implemented aspect-ratio-aware framing around fixed Boston center; improved endpoint sampling to warn+proceed when min distance can’t be met.
- **How to test:** Run `node --test`; then open `index.html?stepsPerSecond=40&zoom=1.4&minStartEndMeters=9000` and resize the window to see framing adjust; try an impossible distance (e.g. `minStartEndMeters=999999`) and confirm HUD warning.
- **Any tradeoffs:** Aspect framing uses a simple cos(latitude) correction (good enough for prototype equirect projection); HUD warnings are capped to a few recent lines.
- **Next follow-up:** Add more `bounds` presets + expose endpointTries as a documented runtime param if needed; consider metric-accurate framing/projection once switching off grid to a road graph.