### PR TITLE
Endpoint sampling: best-effort + tests

### DIFF
--- a/tests/endpointSampling.test.js
+++ b/tests/endpointSampling.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { sampleEndpointPair } from "../main.js";
+
+function makeRng(values) {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+test("endpoint sampling: returns first pair that meets min distance within maxTries", () => {
+  const keys = ["A", "B", "C"]; // chosen via rng
+  const rng = makeRng([
+    0.01, // A
+    0.34, // B  -> try 1: A-B (distance 1) fails
+    0.02, // A
+    0.99, // C  -> try 2: A-C (distance 100) meets
+  ]);
+
+  const randomKey = (r) => keys[Math.floor(r() * keys.length)];
+
+  const pos = {
+    A: { x: 0, y: 0 },
+    B: { x: 1, y: 0 },
+    C: { x: 100, y: 0 },
+  };
+
+  const r = sampleEndpointPair({
+    randomKey,
+    toLatLon: (k) => pos[k],
+    distanceFn: (p, q) => Math.hypot(p.x - q.x, p.y - q.y),
+    minMeters: 50,
+    maxTries: 10,
+    rng,
+  });
+
+  assert.equal(r.minDistanceMet, true);
+  assert.equal(r.tries, 2);
+  assert.equal(r.distanceMeters, 100);
+  assert.ok(
+    (r.startKey === "A" && r.goalKey === "C") || (r.startKey === "C" && r.goalKey === "A"),
+    "expected first satisfying pair to be A-C"
+  );
+});
+
+test("endpoint sampling: when constraint cannot be met, returns max-distance pair and flags best-effort", () => {
+  const seq = ["A", "B", "A", "C", "B", "C"]; // 3 tries: AB, AC, BC
+  const randomKey = () => seq.shift();
+
+  const pos = {
+    A: { x: 0, y: 0 },
+    B: { x: 5, y: 0 },
+    C: { x: 9, y: 0 },
+  };
+
+  const r = sampleEndpointPair({
+    randomKey,
+    toLatLon: (k) => pos[k],
+    distanceFn: (p, q) => Math.abs(p.x - q.x),
+    minMeters: 20, // impossible given max distance 9
+    maxTries: 3,
+    rng: () => 0.5,
+  });
+
+  assert.equal(r.minDistanceMet, false);
+  assert.equal(r.distanceMeters, 9);
+  assert.equal(new Set([r.startKey, r.goalKey]).size, 2);
+  assert.ok(
+    (r.startKey === "A" && r.goalKey === "C") || (r.startKey === "C" && r.goalKey === "A"),
+    "expected best-effort max-distance pair to be A-C"
+  );
+});


### PR DESCRIPTION
## What changed
- Added a pure, testable `sampleEndpointPair()` helper with injectable RNG.
- Endpoint sampling now tries up to `ENDPOINT_SAMPLING_MAX_TRIES` to meet `CONFIG.minStartEndMeters`.
- If the constraint can't be met, we keep the max-distance pair found and set a best-effort flag.
- HUD now shows the sampled distance/tries and a warning when the min-distance constraint wasn't satisfied.

## How to test
- Automated: `node --test`
- Manual:
  1. Run the wallpaper as usual.
  2. Temporarily set `CONFIG.minStartEndMeters` to an impossible value (e.g. `1e9`).
  3. Confirm HUD shows: `min-distance not met; best-effort`.

## Tradeoffs
- `main.js` is now safe to import in Node (tests) by guarding browser-only code behind `if (typeof window !== "undefined") { ... }`.
- Sampling returns the *first* satisfying pair; otherwise best-effort max-distance.

## Next
- Consider exposing `ENDPOINT_SAMPLING_MAX_TRIES` via CONFIG / query param for easier tuning.
- Add telemetry counters (how often best-effort triggers) if needed for tuning.