### PR TITLE
Viz/UX: runtime viz toggles + pacing clamp + clearer current

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,21 +36,25 @@ All params are **optional**. Out-of-range values are **clamped**; non-numeric/in
 
 ### Supported params
 - `sps` (steps per second): integer **[1, 120]** (default **20**)
+- `maxStepsPerFrame`: int **[1, 500]** (default **60**)
 - `zoom`: float **[0.5, 2.0]** (default **1.0**)
 - `hud`: **0|1** (default **1**)
+- `showOpenClosed`: **0|1** (default **1**)
+- `showCurrent`: **0|1** (default **1**)
+- `showPathDuringSearch`: **0|1** (default **0**)
 - `endHoldMs`: int **[0, 60000]** (default: whatever `main.js` ships with)
 - `endAnimMs`: int **[0, 60000]** (default: whatever `main.js` ships with)
 - `minStartEndMeters`: int **[0, 200000]** (default: whatever `main.js` ships with)
 
 ### Examples
 1) Faster search, zoomed in:
-- `index.html?zoom=1.2&sps=30`
+- `index.html?zoom=1.2&sps=45&maxStepsPerFrame=120`
 
-2) Hide the HUD (good for “clean” wallpaper mode):
-- `index.html?zoom=1.2&sps=30&hud=0`
+2) Clean wallpaper mode (hide HUD + hide open/closed sets):
+- `index.html?hud=0&showOpenClosed=0`
 
-3) Longer end hold + minimum start/end distance:
-- `index.html?endHoldMs=5000&endAnimMs=1500&minStartEndMeters=12000`
+3) Show a faint "path hint" during the search (useful for debugging):
+- `index.html?showPathDuringSearch=1&sps=25&zoom=1.1`
 
 ### Edit defaults
 Open `main.js` and adjust `DEFAULT_CONFIG` (or other constants) to change the shipped defaults.


### PR DESCRIPTION
## What changed
- Added runtime (query param) visualization toggles:
  - `showOpenClosed` (default 1)
  - `showCurrent` (default 1)
  - `showPathDuringSearch` (default 0)
- Added pacing clamp:
  - `maxStepsPerFrame` int [1, 500] (default 60) to prevent huge catch-up loops.
- Improved visual clarity on dark background:
  - Closed-set color shifted to amber for stronger contrast vs open cyan.
  - Current node marker upgraded to a high-contrast target (outline + pulse ring + crosshair).
- HUD now displays viz toggles + `sps` + `maxStepsPerFrame` and indicates when open/closed is hidden.
- README updated with new params + 3 example URLs.

## How to test
1. Run locally (any static server) and open:
   - `index.html?showOpenClosed=0` → open/closed dots should disappear; HUD should say hidden.
   - `index.html?showCurrent=0` → current marker should disappear.
   - `index.html?showPathDuringSearch=1` → faint partial path hint should appear during search.
2. Pacing: try `sps=120&maxStepsPerFrame=10` and confirm the search doesn’t attempt to catch up excessively on slow frames.
3. Visual: confirm the current marker stays obvious even with dense open/closed sets.

## Tradeoffs
- `showPathDuringSearch` draws the `cameFrom` chain to the *current* node (a hint), not an optimal-to-goal path.
- `maxStepsPerFrame` can make the effective steps/sec lower than `sps` on very slow frames (intentional safety/CPU clamp).

## Next
- Optional: add keyboard toggles (and reflect in HUD) for live switching without reloading.
- Optional: tune open/closed alpha/size based on set size to reduce overdraw on large searches.