### PR TITLE
Add dist packaging + release workflow

### DIFF
--- a/.github/workflows/package-dist.yml
+++ b/.github/workflows/package-dist.yml
@@ -1,0 +1,27 @@
+name: package-dist
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Build dist
+        run: node scripts/build-dist.js
+      - name: Zip dist
+        run: |
+          cd dist
+          zip -r ../astar-lively-dist.zip .
+      - name: Upload dist zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: astar-lively-dist
+          path: astar-lively-dist.zip

--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ This repo is designed to be loaded directly in **Lively Wallpaper (Windows)**.
 
 Lively will treat it as a Web/HTML wallpaper.
 
-### Option B — load via a local web server (more reliable for dev)
+### Option B — build a `dist/` zip (clean import)
+1. In this repo folder, run:
+   - `npm run build:dist`
+2. Zip the `dist/` folder (or download the artifact from GitHub Actions).
+3. In Lively: **+ Add Wallpaper** → **Browse** → select the zip.
+
+### Option C — load via a local web server (more reliable for dev)
 Some environments are stricter about loading ES modules from `file:///` URLs. If you see a blank screen, use a local server:
 
 1. In this repo folder, start a server:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "type": "module",
   "scripts": {
-    "test": "node --test"
+    "test": "node --test",
+    "build:dist": "node scripts/build-dist.js"
   }
 }

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -1,0 +1,19 @@
+import { mkdirSync, rmSync, cpSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const dist = resolve(root, 'dist');
+
+rmSync(dist, { recursive: true, force: true });
+mkdirSync(dist, { recursive: true });
+
+const files = ['index.html', 'main.js', 'astar.js'];
+for (const file of files) {
+  cpSync(resolve(root, file), resolve(dist, file));
+}
+
+cpSync(resolve(root, 'data'), resolve(dist, 'data'), { recursive: true });
+
+console.log('dist/ ready for Lively import');


### PR DESCRIPTION
Adds 
> build:dist
> node scripts/build-dist.js

dist/ ready for Lively import to create a clean dist folder for Lively import, plus a GitHub Actions workflow to upload a zipped dist artifact on tags (v*) or manual dispatch. README updated with dist-zip install steps.