### PR TITLE
v0.4: roads-based endpoints + perf guardrails

### DIFF
--- a/tests/roadsEndpoints.test.js
+++ b/tests/roadsEndpoints.test.js
@@ -1,0 +1,34 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildRoadPointCacheFromGeojson, snapLatLonToRoadPoint } from "../main.js";
+
+test("roads endpoints: build candidate keys and snap to nearest road point", () => {
+  const geojson = {
+    type: "FeatureCollection",
+    features: [
+      {
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [-0.5, 0],
+            [0.5, 0],
+          ],
+        },
+      },
+    ],
+  };
+
+  const bounds = { north: 1, south: -1, west: -1, east: 1 };
+  const cache = buildRoadPointCacheFromGeojson(geojson, bounds, 10, 10, { stride: 1, maxPoints: 10 });
+
+  assert.equal(cache.points.length, 2);
+  assert.ok(cache.keys.includes("2,5"), "expected key near lon=-0.5, lat=0");
+  assert.ok(cache.keys.includes("7,5"), "expected key near lon=0.5, lat=0");
+
+  const snapped = snapLatLonToRoadPoint(0.2, 0.4, cache.points);
+  assert.ok(snapped, "expected snapping to return a point");
+  assert.equal(snapped.lon, 0.5);
+  assert.equal(snapped.lat, 0);
+});


### PR DESCRIPTION
Adds roads-based endpoint selection (default endpointMode=roads) using cached candidate points derived from the OSM roads layer; keeps min-distance and best-effort behavior. Also adds render guardrails + HUD stats (endpoint distance, last path length, road points count) and a synthetic unit test for road endpoint snapping.\n\nQuery params:\n- endpointMode=roads|random (default roads)\n- showHud=0|1 (alias for hud)