### PR TITLE
Add soak mode + guardrails

### DIFF
--- a/guardrails.js
+++ b/guardrails.js
@@ -1,0 +1,36 @@
+export const DEFAULT_GUARDRAILS = {
+  maxConsecutiveFailures: 4,
+  maxConsecutiveResamples: 6,
+  relaxCycles: 2,
+  relaxedMinStartEndMeters: 1000,
+};
+
+export function updateGuardrails(state, event, limits = DEFAULT_GUARDRAILS) {
+  const next = {
+    consecutiveFailures: state?.consecutiveFailures ?? 0,
+    consecutiveResamples: state?.consecutiveResamples ?? 0,
+    relaxCyclesRemaining: state?.relaxCyclesRemaining ?? 0,
+  };
+
+  if (event === "success") {
+    next.consecutiveFailures = 0;
+    next.consecutiveResamples = 0;
+  } else if (event === "failure") {
+    next.consecutiveFailures += 1;
+  } else if (event === "resample") {
+    next.consecutiveResamples += 1;
+  }
+
+  let triggered = false;
+  if (
+    next.consecutiveFailures >= limits.maxConsecutiveFailures ||
+    next.consecutiveResamples >= limits.maxConsecutiveResamples
+  ) {
+    triggered = true;
+    next.consecutiveFailures = 0;
+    next.consecutiveResamples = 0;
+    next.relaxCyclesRemaining = Math.max(next.relaxCyclesRemaining, limits.relaxCycles);
+  }
+
+  return { state: next, triggered };
+}

--- a/tests/guardrails.test.js
+++ b/tests/guardrails.test.js
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { updateGuardrails } from "../guardrails.js";
+
+test("guardrails: trigger relaxation after consecutive failures", () => {
+  const limits = {
+    maxConsecutiveFailures: 2,
+    maxConsecutiveResamples: 3,
+    relaxCycles: 2,
+    relaxedMinStartEndMeters: 1000,
+  };
+
+  const s0 = { consecutiveFailures: 0, consecutiveResamples: 0, relaxCyclesRemaining: 0 };
+  const r1 = updateGuardrails(s0, "failure", limits);
+  assert.equal(r1.triggered, false);
+  assert.equal(r1.state.consecutiveFailures, 1);
+  assert.equal(r1.state.relaxCyclesRemaining, 0);
+
+  const r2 = updateGuardrails(r1.state, "failure", limits);
+  assert.equal(r2.triggered, true);
+  assert.equal(r2.state.consecutiveFailures, 0);
+  assert.equal(r2.state.relaxCyclesRemaining, 2);
+});


### PR DESCRIPTION
Adds soak mode via ?soak=1 for long-run stability. Tracks cycles/failures/resamples + avg steps/sec on HUD when soak is enabled, and adds guardrails that temporarily relax constraints after repeated failures/resamples (minStartEndMeters lowered; bounds discard disabled while relaxed). Includes pure guardrails helper + unit test.