### PR TITLE
Add help overlay + mode presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ You can tweak runtime behavior by adding query-string parameters to the URL you 
 All params are **optional**. Out-of-range values are **clamped**; non-numeric/invalid values **fall back to defaults** (no errors).
 
 ### Supported params
+- `mode`: **chill|debug** (preset bundle; explicit params still win)
 - `sps` (steps per second): integer **[1, 120]** (default **20**)
 - `maxStepsPerFrame`: int **[1, 500]** (default **60**)
 - `zoom`: float **[0.5, 2.0]** (default **1.0**)
@@ -54,16 +55,19 @@ All params are **optional**. Out-of-range values are **clamped**; non-numeric/in
 - `minStartEndMeters`: int **[0, 200000]** (default: whatever `main.js` ships with)
 
 ### Examples
-1) Faster search, zoomed in:
+1) Chill preset (slow pacing + minimal overlays):
+- `index.html?mode=chill`
+
+2) Faster search, zoomed in:
 - `index.html?zoom=1.2&sps=45&maxStepsPerFrame=120`
 
-2) Clean wallpaper mode (hide HUD + hide open/closed sets):
+3) Clean wallpaper mode (hide HUD + hide open/closed sets):
 - `index.html?hud=0&showOpenClosed=0`
 
-3) Show a faint "path hint" during the search (useful for debugging):
+4) Show a faint "path hint" during the search (useful for debugging):
 - `index.html?showPathDuringSearch=1&sps=25&zoom=1.1`
 
-Tip: press **R** to toggle the roads layer at runtime.
+Tip: press **R** to toggle the roads layer, and **?** to open the help overlay with current settings.
 
 ### Edit defaults
 Open `main.js` and adjust `DEFAULT_CONFIG` (or other constants) to change the shipped defaults.

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         overflow: hidden;
       }
       canvas { display: block; width: 100%; height: 100%; }
-      #hud {
+      #hud, #help {
         position: fixed; left: 14px; top: 12px;
         color: #a8b3c1;
         font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -24,14 +24,21 @@
         box-shadow: 0 12px 34px rgba(0,0,0,0.35);
         user-select: none;
       }
-      #hud b { color: #e6edf3; font-weight: 650; }
-      #hud .dim { color: #7d8a99; }
-      #hud .key { color: #b7c3d4; }
+      #help {
+        left: auto;
+        right: 14px;
+        top: 12px;
+        max-width: min(520px, 48vw);
+      }
+      #hud b, #help b { color: #e6edf3; font-weight: 650; }
+      #hud .dim, #help .dim { color: #7d8a99; }
+      #hud .key, #help .key { color: #b7c3d4; }
     </style>
   </head>
   <body>
     <canvas id="c"></canvas>
     <div id="hud"></div>
+    <div id="help"></div>
     <script type="module" src="./main.js"></script>
   </body>
 </html>

--- a/tests/runtimeConfig.test.js
+++ b/tests/runtimeConfig.test.js
@@ -1,0 +1,42 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { DEFAULT_CONFIG, parseRuntimeConfig } from "../main.js";
+
+test("parseRuntimeConfig defaults remain when no mode is provided", () => {
+  const cfg = parseRuntimeConfig("");
+  assert.equal(cfg.mode, null);
+  assert.equal(cfg.stepsPerSecond, DEFAULT_CONFIG.stepsPerSecond);
+  assert.equal(cfg.maxStepsPerFrame, DEFAULT_CONFIG.maxStepsPerFrame);
+  assert.equal(cfg.hud, DEFAULT_CONFIG.hud);
+  assert.equal(cfg.showOpenClosed, DEFAULT_CONFIG.showOpenClosed);
+  assert.equal(cfg.showCurrent, DEFAULT_CONFIG.showCurrent);
+  assert.equal(cfg.showRoads, DEFAULT_CONFIG.showRoads);
+});
+
+test("parseRuntimeConfig chill preset applies bundled toggles", () => {
+  const cfg = parseRuntimeConfig("?mode=chill");
+  assert.equal(cfg.mode, "chill");
+  assert.equal(cfg.hud, 0);
+  assert.equal(cfg.stepsPerSecond, 12);
+  assert.equal(cfg.maxStepsPerFrame, 30);
+  assert.equal(cfg.showOpenClosed, 0);
+  assert.equal(cfg.showCurrent, 0);
+});
+
+test("parseRuntimeConfig debug preset applies bundled toggles", () => {
+  const cfg = parseRuntimeConfig("?mode=debug");
+  assert.equal(cfg.mode, "debug");
+  assert.equal(cfg.hud, 1);
+  assert.equal(cfg.stepsPerSecond, 45);
+  assert.equal(cfg.maxStepsPerFrame, 140);
+  assert.equal(cfg.showPathDuringSearch, 1);
+});
+
+test("parseRuntimeConfig allows explicit params to override presets", () => {
+  const cfg = parseRuntimeConfig("?mode=chill&hud=1&sps=50");
+  assert.equal(cfg.mode, "chill");
+  assert.equal(cfg.hud, 1);
+  assert.equal(cfg.stepsPerSecond, 50);
+  assert.equal(cfg.maxStepsPerFrame, 30);
+});


### PR DESCRIPTION
Adds  presets to runtime config (explicit params still override) and a help overlay toggled by  showing key toggles/query params. README updated and tests added for preset parsing.