### PR TITLE
Improve ending animation (trace + glow)

### DIFF
--- a/endPhase.js
+++ b/endPhase.js
@@ -1,0 +1,32 @@
+export function stepEndPhase(state, dtMs, config) {
+  let phase = state.phase;
+  let phaseT = state.phaseT + dtMs;
+  let done = false;
+
+  const nextPhase = () => {
+    if (phase === "end-hold") phase = "end-trace";
+    else if (phase === "end-trace") phase = "end-glow";
+    else done = true;
+  };
+
+  while (!done) {
+    const limit =
+      phase === "end-hold"
+        ? config.endHoldMs
+        : phase === "end-trace"
+        ? config.endTraceMs
+        : config.endGlowMs;
+
+    if (limit <= 0) {
+      nextPhase();
+      continue;
+    }
+
+    if (phaseT < limit) break;
+
+    phaseT -= limit;
+    nextPhase();
+  }
+
+  return { phase, phaseT, done };
+}

--- a/tests/endPhase.test.js
+++ b/tests/endPhase.test.js
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { stepEndPhase } from "../endPhase.js";
+
+test("stepEndPhase transitions through end phases with carry", () => {
+  const config = { endHoldMs: 100, endTraceMs: 200, endGlowMs: 300 };
+
+  let state = { phase: "end-hold", phaseT: 0 };
+  state = stepEndPhase(state, 50, config);
+  assert.equal(state.phase, "end-hold");
+  assert.equal(state.phaseT, 50);
+  assert.equal(state.done, false);
+
+  state = stepEndPhase(state, 60, config);
+  assert.equal(state.phase, "end-trace");
+  assert.equal(state.phaseT, 10);
+
+  state = stepEndPhase(state, 250, config);
+  assert.equal(state.phase, "end-glow");
+  assert.equal(state.phaseT, 60);
+
+  state = stepEndPhase(state, 400, config);
+  assert.equal(state.done, true);
+});
+
+test("stepEndPhase skips zero-duration phases", () => {
+  const config = { endHoldMs: 0, endTraceMs: 0, endGlowMs: 10 };
+
+  let state = { phase: "end-hold", phaseT: 0 };
+  state = stepEndPhase(state, 0, config);
+  assert.equal(state.phase, "end-glow");
+  assert.equal(state.phaseT, 0);
+  assert.equal(state.done, false);
+
+  state = stepEndPhase(state, 10, config);
+  assert.equal(state.done, true);
+});


### PR DESCRIPTION
Reworks the post-search completion sequence into an explicit end-phase state machine (end-hold → end-trace → end-glow) with frame-accurate time deltas. Adds a moving dot during trace and a glow pulse/fade during end-glow, then resets to new endpoints.\n\nNew query params:\n- endTraceMs (ms)\n- endGlowMs (ms)\n\nIf not provided, they split legacy endAnimMs ~60/40 by default. Includes unit tests for phase transitions.