### PR TITLE
Road-graph A*: route on OSM network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A* Desktop Background (for Lively Wallpaper)
 
-A lightweight **HTML/Canvas** wallpaper that animates an A* search (open/closed sets + final path) over a prototype grid mapped to the **Greater Boston** bounding box.
+A lightweight **HTML/Canvas** wallpaper that animates an A* search (open/closed sets + final path) over the **Greater Boston** bounding box. By default it routes on the cached OSM road graph, with a grid fallback.
 
 This repo is designed to be loaded directly in **Lively Wallpaper (Windows)**.
 
@@ -50,6 +50,7 @@ All params are **optional**. Out-of-range values are **clamped**; non-numeric/in
 - `showCurrent`: **0|1** (default **1**)
 - `showPathDuringSearch`: **0|1** (default **0**)
 - `showRoads`: **0|1** (default **1**)
+- `graph`: **roads|grid** (default **roads**)
 - `endHoldMs`: int **[0, 60000]** (default: whatever `main.js` ships with)
 - `endAnimMs`: int **[0, 60000]** (default: whatever `main.js` ships with)
 - `minStartEndMeters`: int **[0, 200000]** (default: whatever `main.js` ships with)
@@ -66,6 +67,9 @@ All params are **optional**. Out-of-range values are **clamped**; non-numeric/in
 
 4) Show a faint "path hint" during the search (useful for debugging):
 - `index.html?showPathDuringSearch=1&sps=25&zoom=1.1`
+
+5) Force grid mode (fallback):
+- `index.html?graph=grid`
 
 Tip: press **R** to toggle the roads layer, and **?** to open the help overlay with current settings.
 
@@ -108,5 +112,5 @@ node scripts/fetch-osm-roads.js --format=compact
 ---
 
 ## Notes / roadmap
-- Current graph is a **regular grid** (prototype).
+- Current graph defaults to the **OSM road network** (cached). Use `graph=grid` to fall back to the prototype grid.
 - Road network layer uses cached OSM data (see above).

--- a/road-graph.js
+++ b/road-graph.js
@@ -1,0 +1,117 @@
+import { haversineMeters } from "./astar.js";
+
+const EARTH_METERS_PER_DEG = 111320;
+
+function inBounds(lat, lon, bounds) {
+  if (!bounds) return true;
+  return lat <= bounds.north && lat >= bounds.south && lon >= bounds.west && lon <= bounds.east;
+}
+
+function makeQuantizer(toleranceMeters) {
+  const step = Math.max(1e-9, toleranceMeters / EARTH_METERS_PER_DEG);
+  return {
+    step,
+    key(lat, lon) {
+      const qLat = Math.round(lat / step);
+      const qLon = Math.round(lon / step);
+      return `${qLat},${qLon}`;
+    },
+  };
+}
+
+export function buildRoadGraph(lines, { toleranceMeters = 10, bounds = null, maxNodes = 250000 } = {}) {
+  const quant = makeQuantizer(toleranceMeters);
+  const nodeIndex = new Map();
+  const nodes = [];
+  const adjacencyMaps = [];
+
+  function getNodeId(lat, lon) {
+    const k = quant.key(lat, lon);
+    const existing = nodeIndex.get(k);
+    if (existing != null) {
+      const node = nodes[existing];
+      node.count += 1;
+      const t = 1 / node.count;
+      node.lat += (lat - node.lat) * t;
+      node.lon += (lon - node.lon) * t;
+      return existing;
+    }
+
+    if (nodes.length >= maxNodes) return null;
+    const id = nodes.length;
+    nodeIndex.set(k, id);
+    nodes.push({ id, lat, lon, count: 1 });
+    adjacencyMaps[id] = new Map();
+    return id;
+  }
+
+  function addEdge(a, b, weight) {
+    if (a == null || b == null) return;
+    if (a === b) return;
+    const mapA = adjacencyMaps[a];
+    const prev = mapA.get(b);
+    if (prev == null || weight < prev) mapA.set(b, weight);
+  }
+
+  for (const line of lines || []) {
+    if (!Array.isArray(line) || line.length < 2) continue;
+    let prevId = null;
+    for (const coord of line) {
+      if (!Array.isArray(coord) || coord.length < 2) continue;
+      const [lon, lat] = coord;
+      if (!Number.isFinite(lat) || !Number.isFinite(lon)) continue;
+      if (!inBounds(lat, lon, bounds)) {
+        prevId = null;
+        continue;
+      }
+      const id = getNodeId(lat, lon);
+      if (id == null) continue;
+      if (prevId != null && prevId !== id) {
+        const a = nodes[prevId];
+        const b = nodes[id];
+        const w = haversineMeters(a, b);
+        addEdge(prevId, id, w);
+        addEdge(id, prevId, w);
+      }
+      prevId = id;
+    }
+  }
+
+  const adjacency = adjacencyMaps.map((map) => Array.from(map, ([to, weight]) => ({ to, weight })));
+  const costMaps = adjacencyMaps.map((map) => map);
+  const edges = adjacency.reduce((acc, list) => acc + list.length, 0);
+
+  return {
+    nodes,
+    adjacency,
+    costMaps,
+    edges,
+    toleranceMeters,
+  };
+}
+
+export function randomGraphNode(graph, rng = Math.random) {
+  if (!graph?.nodes?.length) return null;
+  const idx = Math.floor(rng() * graph.nodes.length);
+  return graph.nodes[idx]?.id ?? idx;
+}
+
+export function graphNodeLatLon(graph, id) {
+  const node = graph?.nodes?.[id];
+  if (!node) return null;
+  return { lat: node.lat, lon: node.lon };
+}
+
+export function findNearestGraphNode(graph, lat, lon) {
+  if (!graph?.nodes?.length) return null;
+  let best = null;
+  let bestD = Infinity;
+  for (const node of graph.nodes) {
+    const d = (node.lat - lat) * (node.lat - lat) + (node.lon - lon) * (node.lon - lon);
+    if (d < bestD) {
+      bestD = d;
+      best = node.id;
+    }
+  }
+  return best;
+}

--- a/tests/roadGraph.test.js
+++ b/tests/roadGraph.test.js
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildRoadGraph, findNearestGraphNode, graphNodeLatLon } from "../road-graph.js";
+import { haversineMeters, makeAStarStepper } from "../astar.js";
+
+test("road graph: builds nodes/edges and finds shortest path", () => {
+  const lines = [
+    [
+      [0, 0],
+      [0, 1],
+      [0, 2],
+    ],
+    [
+      [0, 1],
+      [1, 1],
+    ],
+  ];
+
+  const graph = buildRoadGraph(lines, { toleranceMeters: 0.1 });
+
+  assert.equal(graph.nodes.length, 4, "expected 4 unique nodes");
+  assert.equal(graph.edges, 6, "expected 3 undirected edges (6 directed)");
+
+  const start = findNearestGraphNode(graph, 0, 0);
+  const goal = findNearestGraphNode(graph, 2, 0);
+  assert.notEqual(start, null);
+  assert.notEqual(goal, null);
+
+  const stepper = makeAStarStepper({
+    startKey: start,
+    goalKey: goal,
+    neighbors: (k) => graph.adjacency[k].map((edge) => edge.to),
+    cost: (a, b) => graph.costMaps[a]?.get(b) ?? Infinity,
+    heuristic: (a, g) => haversineMeters(graphNodeLatLon(graph, a), graphNodeLatLon(graph, g)),
+  });
+
+  let result = null;
+  for (let i = 0; i < 50; i++) {
+    const r = stepper.step();
+    if (r.done) {
+      result = r;
+      break;
+    }
+  }
+
+  assert.ok(result, "expected A* to finish");
+  assert.equal(result.status, "found");
+  assert.equal(result.path.length, 3, "expected path with 3 nodes");
+});

--- a/tests/runtimeConfig.test.js
+++ b/tests/runtimeConfig.test.js
@@ -12,6 +12,7 @@ test("parseRuntimeConfig defaults remain when no mode is provided", () => {
   assert.equal(cfg.showOpenClosed, DEFAULT_CONFIG.showOpenClosed);
   assert.equal(cfg.showCurrent, DEFAULT_CONFIG.showCurrent);
   assert.equal(cfg.showRoads, DEFAULT_CONFIG.showRoads);
+  assert.equal(cfg.graph, DEFAULT_CONFIG.graph);
 });
 
 test("parseRuntimeConfig chill preset applies bundled toggles", () => {


### PR DESCRIPTION
Implements road-graph A* as a first-class mode. Builds a deduped road graph from cached OSM roads (compact preferred; GeoJSON fallback), samples endpoints from graph nodes, runs A* over the road adjacency list with haversine heuristic, and renders the resulting path as a polyline over the road layer.\n\nAdds query param: graph=roads|grid (default roads), plus HUD stats (#nodes/#edges) and tests for the graph builder + shortest path.