### PR TITLE
Default zoom in to avoid OSM render caps

### DIFF
--- a/main.js
+++ b/main.js
@@ -89,7 +89,9 @@ export const DEFAULT_CONFIG = {
 
   minStartEndMeters: 7000,
   discardIfPathLeavesBounds: true,
-  zoom: 1.0,
+  // Default to a much tighter view so we don't blow past render budgets on OSM data.
+  // (Area scales ~1/zoom^2, so zoom=5 is ~1/25th the area of zoom=1.)
+  zoom: 5.0,
   hud: 1,
 
   // viz toggles


### PR DESCRIPTION
Sets DEFAULT_CONFIG.zoom to 5.0 (≈1/25th the area vs zoom=1) so the default view is much more zoomed-in and we’re less likely to hit OSM render limits/caps.\n\nTests: npm test