### PR TITLE
Fix zoom clamp + expand sea/water query

### DIFF
--- a/main.js
+++ b/main.js
@@ -215,7 +215,7 @@ export function parseRuntimeConfig(search) {
     maxStepsPerFrame,
     // use a delay to drive the fixed-rate stepping loop
     stepDelayMs: 1000 / stepsPerSecond,
-    zoom: readFloat("zoom", base.zoom, 0.5, 2.0),
+    zoom: readFloat("zoom", base.zoom, 0.5, 50.0),
     hud,
     endpointMode,
     graph,

--- a/scripts/fetch-osm-land.js
+++ b/scripts/fetch-osm-land.js
@@ -49,6 +49,9 @@ function buildQuery(bounds) {
       relation["type"="multipolygon"]["natural"~"water|bay"](${south},${west},${north},${east});
       relation["type"="multipolygon"]["water"~"river|riverbank|canal|basin|harbour|reservoir|lake|pond|bay"](${south},${west},${north},${east});
       relation["type"="multipolygon"]["waterway"="riverbank"](${south},${west},${north},${east});
+
+      // Some coastal/ocean water surfaces are tagged as "place=sea".
+      relation["type"="multipolygon"]["place"="sea"](${south},${west},${north},${east});
     );
     (._;>;);
     out geom;`;


### PR DESCRIPTION
Fixes deterministic debug controls:\n- zoom query param was clamped to max 2.0; allow up to 50.0 so zoom=15 actually works\n\nAlso expands water relation query to include place=sea multipolygons (best-effort).\n\nTests: npm test